### PR TITLE
Typo in FR validators

### DIFF
--- a/Resources/translations/validators.fr.yml
+++ b/Resources/translations/validators.fr.yml
@@ -11,7 +11,7 @@ sylius:
             unique: Le slug du produit doit être unique.
             max_length: Le slug du produit ne doit pas dépasser 1 caractère.|Le slug du produit ne doit pas dépasser {{ limit }} caractères.
         code:
-            not_blank: Veillez introduire le code du produit.
+            not_blank: Veuillez introduire le code du produit.
             regex: Le code du produit peut uniquement être constitué de lettres, chiffres, tirets et tirets bas.
             unique: Le code du produit doit être unique.
         name:


### PR DESCRIPTION
Hello there,

Simply noticed a small typo in the fr translation validators and wanted to fix it.

I'm not really sure about the branch to merge it in.

Have a nice day,